### PR TITLE
smaller release binary

### DIFF
--- a/ws/Cargo.lock
+++ b/ws/Cargo.lock
@@ -379,16 +379,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09fc20d2ca12cb9f044c93e3bd6d32d523e6e2ec3db4f7b2939cd99026ecd3f0"
 
 [[package]]
-name = "lock_api"
-version = "0.4.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1cc9717a20b1bb222f333e6a92fd32f7d8a18ddc5a3191a11af45dcbf4dcd16"
-dependencies = [
- "autocfg",
- "scopeguard",
-]
-
-[[package]]
 name = "log"
 version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -453,16 +443,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num_cpus"
-version = "1.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
-dependencies = [
- "hermit-abi 0.3.1",
- "libc",
-]
-
-[[package]]
 name = "obiwan"
 version = "0.1.0"
 dependencies = [
@@ -498,29 +478,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
 
 [[package]]
-name = "parking_lot"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
-dependencies = [
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93f00c865fe7cabf650081affecd3871070f26767e7b2070a3ffae14c654b447"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall",
- "smallvec",
- "windows-targets",
-]
-
-[[package]]
 name = "pin-project-lite"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -551,15 +508,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_syscall"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
-dependencies = [
- "bitflags 1.3.2",
-]
-
-[[package]]
 name = "rustc-demangle"
 version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -577,27 +525,6 @@ dependencies = [
  "linux-raw-sys",
  "windows-sys",
 ]
-
-[[package]]
-name = "scopeguard"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
-
-[[package]]
-name = "signal-hook-registry"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "smallvec"
-version = "1.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
 name = "socket2"
@@ -686,24 +613,9 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
- "num_cpus",
- "parking_lot",
  "pin-project-lite",
- "signal-hook-registry",
  "socket2",
- "tokio-macros",
  "windows-sys",
-]
-
-[[package]]
-name = "tokio-macros"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.22",
 ]
 
 [[package]]

--- a/ws/Cargo.lock
+++ b/ws/Cargo.lock
@@ -615,7 +615,19 @@ dependencies = [
  "mio",
  "pin-project-lite",
  "socket2",
+ "tokio-macros",
  "windows-sys",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.22",
 ]
 
 [[package]]

--- a/ws/Cargo.toml
+++ b/ws/Cargo.toml
@@ -14,3 +14,8 @@ version = "0.1.0"
 authors = ["Julian Stecklina <js@alien8.de>"]
 edition = "2021"
 license = "AGPL-3.0-or-later"
+
+[profile.release]
+lto = true
+codegen-units = 1
+strip = true

--- a/ws/obiwan/Cargo.toml
+++ b/ws/obiwan/Cargo.toml
@@ -11,7 +11,6 @@ anyhow = "1.0.71"
 clap = { version = "4.3.1", features = [ "derive" ] }
 stderrlog = "0.5.4"
 nix = "0.26.2"
-# TODO Strip this down.
-tokio = { version = "1.28.2", features = ["full"] }
+tokio = { version = "1.28.2", default-features = false, features = ["fs", "io-util", "net", "rt", "sync", "time"] }
 binrw = "0.11.2"
 async-trait = "0.1.68"

--- a/ws/obiwan/Cargo.toml
+++ b/ws/obiwan/Cargo.toml
@@ -11,6 +11,6 @@ anyhow = "1.0.71"
 clap = { version = "4.3.1", features = [ "derive" ] }
 stderrlog = "0.5.4"
 nix = "0.26.2"
-tokio = { version = "1.28.2", default-features = false, features = ["fs", "io-util", "net", "rt", "sync", "time"] }
+tokio = { version = "1.28.2", default-features = false, features = [ "fs", "io-util", "net", "rt", "sync", "time", "macros" ] }
 binrw = "0.11.2"
 async-trait = "0.1.68"


### PR DESCRIPTION
Feel free to ignore. I noticed some low-hanging fruits for a smaller release binary.

With these changes, 
- only 76 instead of 88 crates have to be compiled
- the binary size is reduced from 5.9MB to 1.2MB.

PS: Cool project!